### PR TITLE
Raise exception on missing augeasproviders_core

### DIFF
--- a/lib/puppet/provider/syslog/augeas.rb
+++ b/lib/puppet/provider/syslog/augeas.rb
@@ -1,8 +1,10 @@
+# coding: utf-8
 # Alternative Augeas-based providers for Puppet
 #
 # Copyright (c) 2012 Raphaël Pinson
 # Licensed under the Apache License, Version 2.0
 
+raise("Missing augeasproviders_core dependency") if Puppet::Type.type(:augeasprovider).nil?
 Puppet::Type.type(:syslog).provide(:augeas, :parent => Puppet::Type.type(:augeasprovider).provider(:default)) do
   desc "Uses Augeas API to update a syslog.conf entry"
 


### PR DESCRIPTION
People who manage their code with r10k have to resolve dependencies by
hand (or using a generator), as such we now helpfully raise an exception
when miaugeasproviders_core is missing.